### PR TITLE
add flags to `docker run` to make it work on Linux

### DIFF
--- a/brutrb.com/getting-started.md
+++ b/brutrb.com/getting-started.md
@@ -11,6 +11,7 @@ The simplest way to use `mkbrut` is to use an existing [Docker image](https://hu
 docker run \
        -v "$PWD":"$PWD" \
        -w "$PWD" \
+       -u $(id -u):$(id -g) \
        -it \
        thirdtank/mkbrut \
        mkbrut my-new-app
@@ -34,6 +35,7 @@ For now:
 docker run \
        -v "$PWD":"$PWD" \
        -w "$PWD" \
+       -u $(id -u):$(id -g) \
        -it \
        thirdtank/mkbrut \
        mkbrut my-new-app
@@ -55,6 +57,7 @@ To create your app without the demo components:
 docker run \
        -v "$PWD":"$PWD" \
        -w "$PWD" \
+       -u $(id -u):$(id -g) \
        -it \
        thirdtank/mkbrut \
        mkbrut my-new-app --no-demo


### PR DESCRIPTION
# Problem

`mkbrut` sets a UID/GID in the `Dockerfile` to an essentially arbitrary value.
This works fine on MacOS, since Docker is running in a VM.

On Linux, however, `mkbrut` is running as that user, and it lacks permissions
to create files - the entire point of `mkbrut`.

See #44

# Solution

For now, just document that adding `-u $(id -u):$(id -g)` addresses the issue.

Longer term, I don't love this long command line, but it is important that
Brut apps can be set up without having to install a specific version of Ruby.

Closes #44
