### PR TITLE
update Postgres Client installation incantation

### DIFF
--- a/mkbrut/templates/Base/Dockerfile.dx
+++ b/mkbrut/templates/Base/Dockerfile.dx
@@ -38,6 +38,7 @@ RUN apt-get -y clean && \
       curl \
       gnupg \
       lsb-release \
+      postgresql-common  \
       rsync \
       vim
 
@@ -106,8 +107,7 @@ RUN install -m 0755 -d /etc/apt/keyrings && \
 #
 # Also note that the version here should match the version set up in
 # docker-compose.dx.yml
-RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+RUN /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && \
     apt-get update && \
     apt-get -y install postgresql-client-16
 

--- a/mkbrut/templates/segments/Heroku/deploy/Dockerfile
+++ b/mkbrut/templates/segments/Heroku/deploy/Dockerfile
@@ -44,20 +44,19 @@ RUN apt-get update --quiet --yes && \
       gnupg \
       libjemalloc2 \
       lsb-release \
+      postgresql-common \
       rsync \
-      wget && \
-		rm -rf /var/lib/apt/lists /var/cache/apt/archives
+      wget
 
 # Install the PostgreSQL client.  The latest version is not available
 # from Debian, so we set up our own. This should match what's in Dockerfile.dx
 # and ideally the version of Postgres used in production.
 #
 # Incancation is based on: https://www.postgresql.org/download/linux/debian/
-RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+RUN /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && \
     apt-get update && \
     apt-get --yes --quiet install postgresql-client-16 && \
-		rm -rf /var/lib/apt/lists /var/cache/apt/archives
+		rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # Set basic env vars for production
 ENV RACK_ENV="production" \


### PR DESCRIPTION
# Problem

Docker, the system that provides repeatable builds, does not provide
repeatable builds. I realize why - I'm not locking each image to a SHA-1 or
whatever.  It's fine. Ruby's image was updated to debian trixie, which
removed, I dunno, something?  And so Postgres build instructions from last
week just don't work.

# Solution

Examine the Postgres instructions which, thankfully, have been updated, and
adapt those to the `Dockerfile.dx` and Heroku deployment `Dockerfile`.

This also changes the statement to remove the apt cache slightly to preserve
the directories.
