### PR TITLE
Indicate when constraint violation messages are server-generated

### DIFF
--- a/.nvim.lua
+++ b/.nvim.lua
@@ -1,1 +1,0 @@
-useLSP = true

--- a/brut-js/specs/ConstraintViolationMessages.spec.js
+++ b/brut-js/specs/ConstraintViolationMessages.spec.js
@@ -18,9 +18,12 @@ describe("<brut-cv-messages>", () => {
 
     element.createMessages({validityState,inputName})
 
-    assert.equal(element.querySelectorAll("brut-cv").length,2)
+    const brutCvElements = element.querySelectorAll("brut-cv")
+    assert.equal(brutCvElements.length, 2)
     assert.match(element.textContent,new RegExp("This field does not match the pattern","m"))
     assert.match(element.textContent,new RegExp("This field is above the range","m"))
+    assert.equal(brutCvElements[0].getAttribute("client-side"),"")
+    assert.equal(brutCvElements[1].getAttribute("client-side"),"")
 
     element.clearClientSideMessages()
     assert.equal(element.textContent,"")

--- a/brut-js/specs/Form.spec.js
+++ b/brut-js/specs/Form.spec.js
@@ -6,12 +6,12 @@ describe("<brut-form>", () => {
       <form>
         <label>
           <input required type="text" name="text">
-          <brut-cv-messages>
+          <brut-cv-messages input-name="text">
           </brut-cv-messages>
         </label>
         <label>
           <input required type="number" name="number">
-          <brut-cv-messages>
+          <brut-cv-messages input-name="number">
           </brut-cv-messages>
         </label>
         <input type="submit">Save</input>
@@ -133,49 +133,5 @@ describe("<brut-form>", () => {
     assert(!submitted)
     assert(gotValid)
     assert(!gotInvalid)
-  })
-  withHTML(`
-    <brut-form>
-      <form>
-        <label>
-          <input required type="text" name="text">
-        </label>
-        <brut-cv-messages input-name='text'>
-        </brut-cv-messages>
-        <input type="submit">Save</input>
-      </form>
-    </brut-form>
-  `).test("locates the messages for errors based on name", ({window,document,assert}) => {
-
-    const brutForm         = document.querySelector("brut-form")
-    const form             = brutForm.querySelector("form")
-    const button           = form.querySelector("input[type=submit]")
-    const textFieldLabel   = form.querySelector("label:has(input[type=text])")
-
-    let submitted  = false
-    let gotInvalid = false
-    let gotValid   = false
-
-    form.addEventListener("submit", (event) => {
-      event.preventDefault()
-      submitted = true
-    })
-    brutForm.addEventListener("brut:valid", () => {
-      gotValid = true
-    })
-    brutForm.addEventListener("brut:invalid", () => {
-      gotInvalid = true
-    })
-
-    button.click()
-
-    assert(!submitted)
-    assert(!gotValid)
-    assert(gotInvalid)
-    assert.equal(brutForm.getAttribute("submitted-invalid"),"")
-
-    let error = brutForm.querySelector("brut-cv[input-name='text'][key='cv.cs.valueMissing']")
-    assert(error)
-
   })
 })

--- a/brut-js/src/ConstraintViolationMessage.js
+++ b/brut-js/src/ConstraintViolationMessage.js
@@ -15,9 +15,15 @@ import I18nTranslation from "./I18nTranslation"
  * @property {string} key - the i18n translation key to use.  It must map to the `key` of a `<brut-i18n-translation>` on the page or
  * the element will not render any text.
  * @property {string} input-name - the name of the input, used to insert into the message, e.g. "Title is required".
+ * @property {boolean} server-generated if true, this indicates the element's HTML was generated on the server.
+ *           This means that your CSS can target it for display in all cases.  If this is not present,
+ *           you may want to avoid showing this element if the form has not been submitted yet.
+ *           Does not affect behavior.
  * @property {boolean} server-side if true, this indicates the element contains constraint violation messages
- *                                 from the server.  Currently doesn't affect this element's behavior, however
- *                                 AjaxSubmit will use it to locate where it should insert server-side errors.
+ *           from the server.  Does not affect behavior.
+ * @property {boolean} client-side if true, this indicates the element contains constraint violation messages
+ *           from the client, however they may have been generated from the server, since the server may
+ *           re-evaluate the client-side constraints.  Does not affect behavior of this tag.
  *
  * @see I18nTranslation
  * @see ConstraintViolationMessages
@@ -33,12 +39,15 @@ class ConstraintViolationMessage extends BaseCustomElement {
     "key",
     "input-name",
     "server-side",
+    "client-side",
+    "server-generated",
   ]
 
   static createElement(document,attributes) {
     const element = document.createElement(ConstraintViolationMessage.tagName)
     element.setAttribute("key",this.i18nKey("cs", attributes.key))
     element.setAttribute("input-name",attributes["input-name"])
+    element.setAttribute("client-side","")
     if (Object.hasOwn(attributes,"show-warnings")) {
       element.setAttribute("show-warnings",attributes["show-warnings"])
     }
@@ -83,6 +92,12 @@ class ConstraintViolationMessage extends BaseCustomElement {
   }
 
   serverSideChangedCallback({newValueAsBoolean}) {
+    // attribute listed for documentation purposes only
+  }
+  clientSideChangedCallback({newValueAsBoolean}) {
+    // attribute listed for documentation purposes only
+  }
+  serverGeneratedChangedCallback({newValueAsBoolean}) {
     // attribute listed for documentation purposes only
   }
 

--- a/brutrb.com/.vitepress/config.mjs
+++ b/brutrb.com/.vitepress/config.mjs
@@ -130,6 +130,7 @@ export default defineConfig({
         collapsed: true,
         items: [
           { text: "Migration Basics", link: "/recipes/migrations" },
+          { text: "Styling Form Errors", link: "/recipes/form-errors" },
           { text: "Authentication", link: "/recipes/authentication" },
           { text: "Alternate Layouts", link: "/recipes/alternate-layouts" },
           { text: "Blank Layouts", link: "/recipes/blank-layouts" },

--- a/brutrb.com/form-constraints.md
+++ b/brutrb.com/form-constraints.md
@@ -120,7 +120,7 @@ inputs `ValidityState`.  That may look like so:
 ```html {3}
 <input type="text" name="name" required minlength="3">
 <brut-cv-messages input-name="name">
-  <brut-cv input-name="name" key="rangeUnderflow"></brut-cv>
+  <brut-cv input-name="name" client-side key="rangeUnderflow"></brut-cv>
 </brut-cv-messages>
 ```
 
@@ -139,7 +139,7 @@ this HTML:
 ```html {4}
 <input type="text" name="name" required minlength="3">
 <brut-cv-messages input-name="name">
-  <brut-cv input-name="name" key="rangeUnderflow">
+  <brut-cv input-name="name" client-side key="rangeUnderflow">
     This field is too short
   </brut-cv>
 </brut-cv-messages>
@@ -154,13 +154,13 @@ violation, the same general markup is generated:
 ```html {3,4}
 <input type="text" name="name" required minlength="3">
 <brut-cv-messages input-name="name">
-  <brut-cv server-side>
+  <brut-cv server-generated server-side>
     This name has already been taken.
   </brut-cv>
 </brut-cv-messages>
 ```
 
-The `server-side` attribute is set, which can help with CSS targeting.
+The `server-genereted` and `server-side` attributes is set, which can help with CSS targeting.
 
 The *last* piece of this puzzle is a solution for the issue where forms that have
 not yet been submitted are considered to have invalid values by the browser.
@@ -177,7 +177,7 @@ This might lead to HTML like so:
 
     <input type="text" name="name" required minlength="3">
     <brut-cv-messages input-name="name">
-      <brut-cv input-name="name" key="rangeUnderflow">
+      <brut-cv input-name="name" client-side key="rangeUnderflow">
         This field is too short
       </brut-cv>
     </brut-cv-messages>
@@ -199,7 +199,7 @@ brut-cv {
 /* brut-cv inside a submitted-invalid
    OR brut-cv from the server ARE shown */
 brut-form[submitted-invalid] brut-cv,
-brut-cv[server-side] {
+brut-cv[server-generated] {
   display: block;
   color: red; /* e.g. */
 }

--- a/brutrb.com/recipes/form-errors.md
+++ b/brutrb.com/recipes/form-errors.md
@@ -1,0 +1,148 @@
+# Styling Form Errors
+
+Brut makes it as easy as possible to unify client-side and server-side constraint violation handling, including
+how you style those messages.
+
+## Requirements
+
+What you want:
+
+* When a form is rendered for the first time, there should be errors shown.
+* When a visitor interacts with a form before submissions, no errors are shown.
+* When the form is submitted, client-side constraint violations should be shown.
+* When JavaScript is circumvented and the form is submitted with client-side constraint violations, the form should be re-generated, showing those violations the same is if JavaScripts was *not* circumvented
+* When there are no client-side constraint violations, but there *are* server-side violations, the form should be re-generated, showing those violations the same is if JavaScripts was *not* circumvented
+
+This can be achieved through CSS.
+
+## Recipe
+
+### Create Pages and HTML
+
+First, create a form and handler:
+
+```
+bin/scaffold form /new_widget
+```
+
+Edit `app/src/front_end/forms/new_widget_form.rb`
+
+```ruby
+class NewWidgetForm < AppForm
+  input :name, minlength: 3
+  input :description
+end
+```
+
+Now, implement the handler in `app/src/front_end/handlers/new_widget_handler.rb` to check for client-side violations *and* require that the description have at
+least 5 words in it.
+
+```ruby
+class NewWidgetHandler < AppHandler
+  def initialize(form:)
+    @form = form
+  end
+
+  def handle
+    if @form.valid?
+      if @form.description.split(/\s+/).length < 5
+      @form.server_side_constraint_violation(
+        input_name: :description,
+        key: :not_enough_words
+      )
+    end
+
+    if @form.constraint_violations?
+      NewWidgetPage.new(form: @form)
+    else
+      redirect_to(HomePage)
+    end
+  end
+end
+```
+
+Add the new error message to `app/config/i18n/en/2_app.rb`
+
+```ruby {6}
+{
+  en: {
+    nevermind: "Nevermind",
+    cv: {
+      ss: {
+        not_enough_words: "%{field} must have at least %{minwords} words",
+      },
+      # ...
+```
+
+Now, build a minimal `NewWidgetPage`:
+
+```
+bin/scaffold page /new_widget`
+```
+
+We'll create the bare minimum in `app/src/front_end/pages/new_widget_page.rb`
+
+```ruby
+class NewWidgetPage < AppPage
+  def initialize(form: nil)
+    @form = form || NewWidgetForm.new
+  end
+
+  def page_template
+    brut_form do
+      FormTag(for: @form) do
+        label do
+          Inputs::InputTag(form: @form, input_name: :name)
+          ConstraintViolations(form: @form, input_name: :name)
+          span { "Name" }
+        end
+        label do
+          Inputs::TextareaTag(form: @form, input_name: :name)
+          ConstraintViolations(form: @form, input_name: :name)
+          span { "Description" }
+        end
+      end
+    end
+  end
+end
+```
+
+### Create CSS
+
+The most minimal CSS would be as followed, which you can place in `app/src/front_end/css/index.css`
+
+```css
+brut-cv {
+  display: none;
+}
+
+brut-form[submitted-invalid] brut-cv,
+brut-cv[server-generated] {
+  display: block;
+  color: red;
+}
+```
+
+This will show the messages in `<brut-cv>` *only* if:
+
+* Form submission was attempted (`submitted-invalid` would be set on `<brut-form>`)
+* The server generated via `ConstraintViolations` (only if the handler was triggered)
+
+Because more than one `<brut-cv>` could be generated or inserted, you may want to style the
+`<brut-cv-messages>` that contains them, but you only want it to show up if it has contents.
+
+You can't just do `brut-cv-messages:has(brut-cv)`, because your container would show up before the form
+submission was attempted.
+
+Here is what you want instead. This will put the error messages in a red box:
+
+```css
+brut-form[submitted-invalid] brut-cv-messages:has(brut-cv),
+brut-cv-messages:has(brut-cv[server-generated]) {
+  color: red;
+  background-color: pink;
+  border: solid thin red;
+  border-radius: 1rem;
+}
+```
+


### PR DESCRIPTION
Server-generated client-side constraint violations can exist, so this makes it
clear what is happening. Fixes a potential issue where client-side violations
that were generated from the server don't show up.

Fixes #37
