### PR TITLE
Explicit handling of buttons with forms

### DIFF
--- a/brut-js/specs/AjaxSubmit.spec.js
+++ b/brut-js/specs/AjaxSubmit.spec.js
@@ -348,4 +348,58 @@ Error that should be ignored
       })
     })
   })
+  withHTML(`
+    <form action="http://example.net/foo" method="POST">
+      <input required type="text" name="some-text">
+      <input required type="number" name="some-number">
+      <brut-ajax-submit submitted-lifetime="10">
+        <input type="submit" name="button-name" value="button-value">
+      </brut-ajax-submit>
+    </form>
+  `).onFetch( "/foo", [
+    { then: { status: 200, text: "<div>some html</div>" }},
+  ]
+  ).test("submits the form, when wrapped around an input type=submi, setting various attributes during the lifecycle", 
+         ({document,assert,fetchRequests,waitForSetTimeout,readRequestBodyIntoString}) => {
+
+    const element = document.querySelector("brut-ajax-submit")
+    const button  = element.querySelector("input[type=submit]") 
+    const text    = document.querySelector("input[name=some-text]")
+    const number  = document.querySelector("input[name=some-number]")
+
+    let okReceived = false
+    let detailReceived = null
+    element.addEventListener("brut:submitok", (event) => {
+      okReceived = true
+      detailReceived = event.detail
+    })
+
+    text.value   = "Some Text"
+    number.value = "11"
+
+    button.click()
+    assert(element.getAttribute("requesting") != null)
+
+    const promises = fetchRequests.
+      filter( (fetchRequest) => fetchRequest.promiseReturned ).
+      map( (fetchRequest) => fetchRequest.promiseReturned )
+
+    return Promise.all(promises).then( () => {
+      assert(okReceived)
+      assert(detailReceived)
+      assert.equal(detailReceived.body.innerHTML,"<div>some html</div>")
+      assert(element.getAttribute("requesting") == null)
+      assert(element.getAttribute("submitted") != null)
+      return waitForSetTimeout(11).then( () => {
+        assert(element.getAttribute("submitted") == null)
+        return readRequestBodyIntoString(fetchRequests[0]).then( (string) => {
+          const params = new URLSearchParams(string)
+          assert.equal(params.get("some-text"),"Some Text")
+          assert.equal(params.get("some-number"),"11")
+          assert.equal(params.get("button-name"),"button-value")
+        })
+      })
+
+    })
+  })
 })

--- a/brut-js/specs/AjaxSubmit.spec.js
+++ b/brut-js/specs/AjaxSubmit.spec.js
@@ -6,7 +6,7 @@ describe("<brut-ajax-submit>", () => {
       <input required type="text" name="some-text">
       <input required type="number" name="some-number">
       <brut-ajax-submit submitted-lifetime="10">
-        <button>Submit</button>
+        <button name="button-name" value="button-value">Submit</button>
       </brut-ajax-submit>
     </form>
   `).onFetch( "/foo", [
@@ -43,12 +43,13 @@ describe("<brut-ajax-submit>", () => {
       assert.equal(detailReceived.body.innerHTML,"<div>some html</div>")
       assert(element.getAttribute("requesting") == null)
       assert(element.getAttribute("submitted") != null)
-      waitForSetTimeout(11).then( () => {
+      return waitForSetTimeout(11).then( () => {
         assert(element.getAttribute("submitted") == null)
         return readRequestBodyIntoString(fetchRequests[0]).then( (string) => {
           const params = new URLSearchParams(string)
           assert.equal(params.get("some-text"),"Some Text")
           assert.equal(params.get("some-number"),"11")
+          assert.equal(params.get("button-name"),"button-value")
         })
       })
 
@@ -79,7 +80,7 @@ describe("<brut-ajax-submit>", () => {
       <input required type="text" name="some-text">
       <input required type="number" name="some-number">
       <brut-ajax-submit submitted-lifetime="10">
-        <button>Submit</button>
+        <button name="button-name" value="button-value">Submit</button>
       </brut-ajax-submit>
     </form>
   `).onFetch( "/foo", [
@@ -114,6 +115,7 @@ describe("<brut-ajax-submit>", () => {
           const params = new URLSearchParams(string)
           assert.equal(params.get("some-text"),"Some Text")
           assert.equal(params.get("some-number"),"11")
+          assert.equal(params.get("button-name"),"button-value")
         })
       })
     })
@@ -123,7 +125,7 @@ describe("<brut-ajax-submit>", () => {
       <input required type="text" name="some-text">
       <input required type="number" name="some-number">
       <brut-ajax-submit submitted-lifetime="10" max-retry-attempts=2>
-        <button>Submit</button>
+        <button name="button-name" value="button-value">Submit</button>
       </brut-ajax-submit>
     </form>
   `).onFetch( "/foo", [
@@ -183,7 +185,7 @@ describe("<brut-ajax-submit>", () => {
       </brut-cv-messages>
 
       <brut-ajax-submit submitted-lifetime="10">
-        <button>Submit</button>
+        <button name="button-name" value="button-value">Submit</button>
       </brut-ajax-submit>
     </form>
   `).onFetch( "/foo", [
@@ -283,7 +285,7 @@ Error that should be ignored
       </brut-cv-messages>
 
       <brut-ajax-submit submitted-lifetime="10" no-server-side-error-parsing>
-        <button>Submit</button>
+        <button name="button-name" value="button-value">Submit</button>
       </brut-ajax-submit>
     </form>
   `).onFetch( "/foo", [

--- a/brut-js/src/AjaxSubmit.js
+++ b/brut-js/src/AjaxSubmit.js
@@ -278,7 +278,14 @@ class AjaxSubmit extends BaseCustomElement {
     })
   }
 
-  #button = () => { return this.querySelector("button") }
+  #button = () => {
+    let button = this.querySelector("button")
+    if (!button) {
+      button = this.querySelector("input[type='submit']")
+    }
+    return button
+  }
+
 
   #submitFormThroughBrowser(form) {
     form.removeEventListener("submit",this.#formSubmitted)

--- a/brutrb.com/forms.md
+++ b/brutrb.com/forms.md
@@ -83,6 +83,7 @@ for use in a radio button group. |
 |`Brut::FrontEnd::Components::SelectTagWithOptions` | Creates a `<select>` tag with
 `<option>` tags inside. |
 |`Brut::FrontEnd::Components::TextareaTag` | Creates a `<textarea>` tag. |
+|`Brut::FrontEnd::Components::ButtonTag` | Creates a `<button>` tag to submit the form. |
 
 All of these classes have an initializer that accepts:
 

--- a/lib/brut/front_end/components/input.rb
+++ b/lib/brut/front_end/components/input.rb
@@ -3,6 +3,7 @@ module Brut::FrontEnd::Components
   # Holds components designed to render HTML `<input>` and other form components.
   module Inputs
     autoload(:InputTag,"brut/front_end/components/inputs/input_tag")
+    autoload(:ButtonTag,"brut/front_end/components/inputs/button_tag")
     autoload(:RadioButton,"brut/front_end/components/inputs/radio_button")
     autoload(:SelectTagWithOptions,"brut/front_end/components/inputs/select_tag_with_options")
     autoload(:TextareaTag,"brut/front_end/components/inputs/textarea_tag")

--- a/lib/brut/front_end/components/inputs/button_tag.rb
+++ b/lib/brut/front_end/components/inputs/button_tag.rb
@@ -1,0 +1,40 @@
+# Creates a button tag to be used inside a form. This is only 
+# needed if your form declared a `button` and you wish the value
+# to be included whern the form is submitted (for example, if you have
+# more than one submit button and wish to know which one was clicked on the
+# back end).
+class Brut::FrontEnd::Components::Inputs::ButtonTag < Brut::FrontEnd::Components::Input
+
+  # Creates the appropriate button for the given {Brut::FrontEnd::Form} and input name.
+  #
+  # @param [Brut::FrontEnd::Form} form The form that is being rendered. This method will consult this class to understand the requirements on this input so its HTML is generated correctly.
+  # @param [String] input_name the name of the input, which should be a member of `form`
+  # @param [Integer] index if this input is part of an array, this is the index into that array. This is used to get the input's value.
+  # @param [Hash] html_attributes any additional HTML attributes to include on the `<input>` element. Note 
+  #               that if you set `type` here to be `reset` or `button`, this button will not submit
+  #               the form (as per the HTML spec).  Also note that the various
+  #               `form*` attributes *will* take effect and work as desired.
+  def initialize(form:, input_name:, index: nil, **html_attributes)
+    input = form.input(input_name, index:)
+    if input.class.name != "Brut::FrontEnd::Forms::Button"
+      raise ArgumentError, "#{self.class} can only be used with `button` elements, not #{input.class.name} form elements"
+    end
+    default_html_attributes = {}
+    html_attributes = html_attributes.map { |key,value| [ key.to_sym, value ] }.to_h
+
+    default_html_attributes[:name] = if input.array?
+                                       "#{input.name}[]"
+                                     else
+                                       input.name
+                                     end
+    default_html_attributes[:value] = input.value
+
+    @attributes = default_html_attributes.merge(html_attributes)
+  end
+
+  def view_template
+    button(**@attributes) do
+      yield
+    end
+  end
+end

--- a/lib/brut/front_end/components/inputs/input_tag.rb
+++ b/lib/brut/front_end/components/inputs/input_tag.rb
@@ -10,6 +10,9 @@ class Brut::FrontEnd::Components::Inputs::InputTag < Brut::FrontEnd::Components:
   # @param [Hash] html_attributes any additional HTML attributes to include on the `<input>` element.
   def initialize(form:, input_name:, index: nil, **html_attributes)
     input = form.input(input_name, index:)
+    if input.class.name != "Brut::FrontEnd::Forms::Input"
+      raise ArgumentError, "#{self.class} can only be used with `input` elements, not #{input.class.name} form elements"
+    end
     default_html_attributes = {}
     html_attributes = html_attributes.map { |key,value| [ key.to_sym, value ] }.to_h
 

--- a/lib/brut/front_end/components/inputs/input_tag.rb
+++ b/lib/brut/front_end/components/inputs/input_tag.rb
@@ -3,7 +3,6 @@ class Brut::FrontEnd::Components::Inputs::InputTag < Brut::FrontEnd::Components:
   def invalid? = @attributes["data-invalid"] == true
 
   # Creates the appropriate input for the given {Brut::FrontEnd::Form} and input name.
-  # Generally, you want to use this method over the initializer.
   #
   # @param [Brut::FrontEnd::Form} form The form that is being rendered. This method will consult this class to understand the requirements on this input so its HTML is generated correctly.
   # @param [String] input_name the name of the input, which should be a member of `form`

--- a/lib/brut/front_end/components/inputs/select_tag_with_options.rb
+++ b/lib/brut/front_end/components/inputs/select_tag_with_options.rb
@@ -1,7 +1,6 @@
 # Renders an HTML `<select>`.
 class Brut::FrontEnd::Components::Inputs::SelectTagWithOptions < Brut::FrontEnd::Components::Input
   # Creates the appropriate select input for the given {Brut::FrontEnd::Form} and input name.
-  # Generally, you want to use this method over the initializer.
   #
   # @param [Brut::FrontEnd::Form} form The form that is being rendered.
   #        This method will consult this class to understand the requirements

--- a/lib/brut/front_end/components/inputs/textarea_tag.rb
+++ b/lib/brut/front_end/components/inputs/textarea_tag.rb
@@ -2,7 +2,6 @@
 class Brut::FrontEnd::Components::Inputs::TextareaTag < Brut::FrontEnd::Components::Input
 
   # Creates the appropriate textarea for the given {Brut::FrontEnd::Form} and input name.
-  # Generally, you want to use this method over the initializer.
   #
   # @param [Brut::FrontEnd::Form} form The form that is being rendered. This method will consult this class to understand the requirements on this textarea so its HTML is generated correctly.
   # @param [String] input_name the name of the input, which should be a member of `form`

--- a/lib/brut/front_end/form.rb
+++ b/lib/brut/front_end/form.rb
@@ -40,11 +40,11 @@ class Brut::FrontEnd::Form
       Brut.container.instrumentation.add_attributes(prefix: :brut, ignored_unknown_params: unknown_params.join(","))
     end
     @params = params.except(*unknown_params).map { |name,value|
-        input_definition = begin
-                             self.class.input_definitions[name] || self.class.input_definitions.fetch(name.to_s)
-                           rescue KeyError
-                             raise "cannot find input definition for '#{name}'. Have these: #{self.class.input_definitions.keys.inspect}"
-                           end
+      input_definition = begin
+                           self.class.input_definitions[name] || self.class.input_definitions.fetch(name.to_s)
+                         rescue KeyError
+                           raise "cannot find input definition for '#{name}'. Have these: #{self.class.input_definitions.keys.inspect}"
+                         end
       if value.kind_of?(Array)
         input_definition = begin
                              self.class.input_definitions[name] || self.class.input_definitions.fetch(name.to_s)

--- a/lib/brut/front_end/form.rb
+++ b/lib/brut/front_end/form.rb
@@ -5,10 +5,12 @@ module Brut::FrontEnd::Forms
   autoload(:InputDeclarations, "brut/front_end/forms/input_declarations")
   autoload(:InputDefinition, "brut/front_end/forms/input_definition")
   autoload(:SelectInputDefinition, "brut/front_end/forms/select_input_definition")
+  autoload(:ButtonInputDefinition, "brut/front_end/forms/button_input_definition")
   autoload(:RadioButtonGroupInputDefinition, "brut/front_end/forms/radio_button_group_input_definition")
   autoload(:ConstraintViolation, "brut/front_end/forms/constraint_violation")
   autoload(:ValidityState, "brut/front_end/forms/validity_state")
   autoload(:Input, "brut/front_end/forms/input")
+  autoload(:Button, "brut/front_end/forms/button")
   autoload(:SelectInput, "brut/front_end/forms/select_input")
   autoload(:RadioButtonGroupInput, "brut/front_end/forms/radio_button_group_input")
 end

--- a/lib/brut/front_end/forms/button.rb
+++ b/lib/brut/front_end/forms/button.rb
@@ -1,0 +1,21 @@
+# Represents the current state of a particular button that is part of a form.
+# Button's in this context don't really have state, but this allows the button to be
+# modeled like any other form element.
+class Brut::FrontEnd::Forms::Button < Brut::FrontEnd::Forms::Input
+  # Create the input with the given definition and value
+  # @param [Brut::FrontEnd::Forms::InputDefinition] input_definition
+  # @param [String] value Value of the button, which would be submitted with the form. Note
+  #                       that {Brut::FrontEnd::Forms::ButtonInputDefinition#make_input} will
+  #                       default this value to `"true"`.
+  def initialize(input_definition:, value:, index:)
+    @input_definition = input_definition
+    @validity_state = Brut::FrontEnd::Forms::ValidityState.new
+    @index = index
+    self.value=(value)
+  end
+
+  def value=(new_value)
+    @value = new_value.to_s
+    @typed_value = @value
+  end
+end

--- a/lib/brut/front_end/forms/button_input_definition.rb
+++ b/lib/brut/front_end/forms/button_input_definition.rb
@@ -1,0 +1,37 @@
+# Defines a button to be used to submit a form (as opposed to an `<input type="submit">`).
+# This is needed when the name/value of the button should be submitted witih the form.
+class Brut::FrontEnd::Forms::ButtonInputDefinition
+  include Brut::Framework::FussyTypeEnforcement
+
+  attr_reader :name
+
+  # Create a ButtonInputDefinition.
+  #
+  # @param [String] name Name of the button (required)
+  # @param [true|false] array If true, the form will expect multiple values for this input.  The values will be available as an array. Any values omitted by the user will be present as empty strings.
+  #
+  # @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button BUTTON Element
+  def initialize(
+    name:,
+    array: false
+  )
+    name  = name.to_s
+    @name  = type!(name,  String,        "name",  required: true)
+    @array = type!(array, [true, false], "array", required: true)
+  end
+
+  def array? = @array
+
+
+  # Create an Input based on this definition, initializing it with the given value.
+  # @param [String] value the value to give this input initially. If this is blank,
+  #                 the button's value will be `"true"`.
+  # @param [Integer] index the index of this input, if it is part of an array of
+  #                  inputs. `nil` is allowed only if the input definition is not for an array.
+  def make_input(value:, index:)
+    if value.to_s.strip == ""
+      value = "true"
+    end
+    Brut::FrontEnd::Forms::Button.new(input_definition: self, value:, index:)
+  end
+end

--- a/lib/brut/front_end/forms/input_declarations.rb
+++ b/lib/brut/front_end/forms/input_declarations.rb
@@ -11,6 +11,16 @@ module Brut::FrontEnd::Forms::InputDeclarations
     )
   end
 
+  # Declares a named button for this form, which is required in order to have this button's name and
+  # value sent to the back.  This will generate a `<button>` tag. To use `<input type="submit">`, {.input} should
+  # be used instead.
+  # @param [String] name The name of the button (used in the `name` attribute)
+  def button(name)
+    self.add_input_definition(
+      Brut::FrontEnd::Forms::ButtonInputDefinition.new(name:)
+    )
+  end
+
   # Declares a select for this form, to be modeled via an HTML `<SELECT>` tag. Note that this will not define the values that appear
   # in the select.  That is done when the select is rendered, which you might do with a
   # {Brut::FrontEnd::Components::Inputs::Select}

--- a/lib/brut/front_end/forms/input_definition.rb
+++ b/lib/brut/front_end/forms/input_definition.rb
@@ -32,6 +32,7 @@ class Brut::FrontEnd::Forms::InputDefinition
     "radio"          => String,
     "range"          => String,
     "search"         => String,
+    "submit"         => String,
     "tel"            => String,
     "text"           => String,
     "time"           => Time, # XXX
@@ -49,7 +50,7 @@ class Brut::FrontEnd::Forms::InputDefinition
   # @param [Integer] maxlength Maximum length of the value allowed.
   # @param [String] name Name of the input (required)
   # @param [Regexp] pattern that the value must match. Note that this technically must be a regular expression that works for both Ruby and JavaScript, so don't get fancy.
-  # @param [true|false] required true if this field is required, false otherwise. Default is `true` unless `type` is `"checkbox"`.
+  # @param [true|false] required true if this field is required, false otherwise. Default is `true` unless `type` is `"checkbox"` or `"submit"`.
   # @param [Integer] step Step value for ranged inputs.  A value that is not on a step is considered invalid.
   # @param [String] type the type of input to create. Should be a value from the HTML spec. Default is based on the value of `name`. If `email`, `type` is `email`. If `password` or `password_confirmation`, type is `password`. Otherwise `text`.
   # @param [true|false] array If true, the form will expect multiple values for this input.  The values will be available as an array. Any values omitted by the user will be present as empty strings.
@@ -84,7 +85,11 @@ class Brut::FrontEnd::Forms::InputDefinition
 
     type = type.to_s
     if required == :based_on_type
-      required = type != "checkbox"
+      required = case type
+                 when "checkbox" then false
+                 when "submit"   then false
+                 else true
+                 end
     end
 
     @max       = max


### PR DESCRIPTION
Fixes #58

Additionally:

* `<brut-ajax-submit>` now works with `<input type="submit">`.
* Doc fixes
* Additional error handling
