### PR TITLE
fix build_assets rsync for paths containing spaces

### DIFF
--- a/lib/brut/cli/apps/build_assets.rb
+++ b/lib/brut/cli/apps/build_assets.rb
@@ -33,7 +33,7 @@ This is to ensure that any images your code references will end up in the public
       src_dir  = Brut.container.images_src_dir
       dest_dir = Brut.container.images_root_dir
 
-      command = "rsync --archive --delete --verbose #{src_dir}/ #{dest_dir}"
+      command = "rsync --archive --delete --verbose \"#{src_dir}/\" \"#{dest_dir}\""
       system! command
     end
   end


### PR DESCRIPTION
Hi,

If any folder in the directory path of the project has spaces, the rsync would fail. By having the path in quotes, this is covered.

Daniel